### PR TITLE
Bump Siddhi version to 5.1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
         <carbon.feature.plugin.version>3.1.1</carbon.feature.plugin.version>
         <maven.surefire.plugin.version>2.12.4</maven.surefire.plugin.version>
         <testng.version>6.8</testng.version>
-        <siddhi.map.xml.version>5.0.3</siddhi.map.xml.version>
-        <siddhi.map.binary.version>2.0.2</siddhi.map.binary.version>
+        <siddhi.map.xml.version>5.0.4</siddhi.map.xml.version>
+        <siddhi.map.binary.version>2.0.5</siddhi.map.binary.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jacoco.version>0.7.9</jacoco.version>
         <transport.version>6.0.272</transport.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     </scm>
 
     <properties>
-        <siddhi.version>5.1.2</siddhi.version>
+        <siddhi.version>5.1.13</siddhi.version>
         <siddhi.version.range>[5.0.0,6.0.0)</siddhi.version.range>
         <carbon.feature.plugin.version>3.1.1</carbon.feature.plugin.version>
         <maven.surefire.plugin.version>2.12.4</maven.surefire.plugin.version>


### PR DESCRIPTION
## Purpose
> Bump Siddhi version to 5.1.13

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes